### PR TITLE
Fix security vulnerabilities and disable web security in puppeteer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1426,9 +1426,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/src/fetcher/puppeteer.ts
+++ b/src/fetcher/puppeteer.ts
@@ -20,7 +20,7 @@ export default class PuppeteerFetcher implements Fetcher {
     const userAgent = randomUserAgent.getRandom();
     const browser = await browserType.launch({
       headless: true,
-      args: ['--no-sandbox', '--disable-setuid-sandbox', '--allow-insecure'],
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--allow-insecure', '--disable-web-security'],
       ignoreHTTPSErrors: true,
     });
 


### PR DESCRIPTION
This PR adds the `--disable-web-security` flag for puppeteer and fixes some security issues in the dependencies. 