### PR TITLE
Improve puppeteer options

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Test scraping contracts
+name: Tests
 on:
   pull_request:
     branches:

--- a/index.ts
+++ b/index.ts
@@ -36,7 +36,7 @@ class Scraper {
     url: string,
     contract: any,
     attributes: Attributes = {},
-    puppeteerOptions: PuppeteerNodeLaunchOptions = {},
+    puppeteerOptions?: PuppeteerNodeLaunchOptions,
   ) {
     this.url = url;
     this.contract = contract;
@@ -119,15 +119,15 @@ class Scraper {
   }
 
   public getFetcher(): Fetcher {
-    if (this.contract.puppeteer === false) {
-      return new RequestFetcher(this.url);
+    if (this.contract.puppeteer === true) {
+      return new PuppeteerFetcher(
+        this.url,
+        this.contract.waitForPageLoadSelector,
+        this.puppeteerOptions,
+      );
     }
 
-    return new PuppeteerFetcher(
-      this.url,
-      this.contract.waitForPageLoadSelector,
-      this.puppeteerOptions,
-    );
+    return new RequestFetcher(this.url);
   }
 
   public getProvider(page: ScrapedPage, attributes: any): Provider {

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,7 @@ import ScriptTagProvider from './src/provider/script-tag';
 import buildSchema from './src/contract-schema';
 import RequestFetcher from './src/fetcher/request';
 import * as cheerio from 'cheerio';
+import { PuppeteerNodeLaunchOptions } from 'puppeteer';
 
 interface Attributes {
   [name: string]: any;
@@ -29,11 +30,18 @@ class Scraper {
   private url: string;
   private contract: any;
   private attributes: Attributes;
+  private puppeteerOptions: PuppeteerNodeLaunchOptions;
 
-  constructor(url: string, contract: any, attributes: Attributes = {}) {
+  constructor(
+    url: string,
+    contract: any,
+    attributes: Attributes = {},
+    puppeteerOptions: PuppeteerNodeLaunchOptions = {},
+  ) {
     this.url = url;
     this.contract = contract;
     this.attributes = attributes;
+    this.puppeteerOptions = puppeteerOptions;
   }
 
   public scrapePage(): Promise<any[]> {
@@ -118,7 +126,7 @@ class Scraper {
     return new PuppeteerFetcher(
       this.url,
       this.contract.waitForPageLoadSelector,
-      this.contract.headless,
+      this.puppeteerOptions,
     );
   }
 

--- a/index.ts
+++ b/index.ts
@@ -54,7 +54,10 @@ class Scraper {
     });
   }
 
-   public async getPageContents(): Promise<{ page: ScrapedPage, $: cheerio.Root }> {
+  public async getPageContents(): Promise<{
+    page: ScrapedPage;
+    $: cheerio.Root;
+  }> {
     const attributes = this.getAttributes();
     const { message } = this.contractIsValid(attributes);
 
@@ -67,12 +70,12 @@ class Scraper {
     }
 
     const fetcher = this.getFetcher();
-    const page = await fetcher.getPage()
+    const page = await fetcher.getPage();
 
     return {
       page,
       $: cheerio.load(page.contents),
-    }
+    };
   }
 
   public getScrapedItems(page: ScrapedPage, attributes: any) {
@@ -93,9 +96,9 @@ class Scraper {
     }
   }
 
-  public contractIsValid(attributes: {
-    [name: string]: any;
-  }): { message: string | null } {
+  public contractIsValid(attributes: { [name: string]: any }): {
+    message: string | null;
+  } {
     if (this.contract === null || this.contract === undefined) {
       return {
         message: 'Your contract is invalid, please check the specifications',
@@ -112,7 +115,11 @@ class Scraper {
       return new RequestFetcher(this.url);
     }
 
-    return new PuppeteerFetcher(this.url);
+    return new PuppeteerFetcher(
+      this.url,
+      this.contract.waitForPageLoadSelector,
+      this.contract.headless,
+    );
   }
 
   public getProvider(page: ScrapedPage, attributes: any): Provider {

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,9 +483,9 @@
       "dev": true
     },
     "@types/cheerio": {
-      "version": "0.22.28",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.28.tgz",
-      "integrity": "sha512-ehUMGSW5IeDxJjbru4awKYMlKGmo1wSSGUVqXtYwlgmUM8X1a0PZttEIm6yEY7vHsY/hh6iPnklF213G0UColw==",
+      "version": "0.22.29",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.29.tgz",
+      "integrity": "sha512-rNX1PsrDPxiNiyLnRKiW2NXHJFHqx0Fl3J2WsZq0MTBspa/FgwlqhXJE2crIcc+/2IglLHtSWw7g053oUR8fOg==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3024,9 +3024,9 @@
       }
     },
     "ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g=="
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "dist/src"
   ],
   "devDependencies": {
-    "@types/cheerio": "^0.22.28",
+    "@types/cheerio": "^0.22.29",
     "@types/expect": "^24.3.0",
     "@types/mocha": "^8.2.2",
     "@types/puppeteer": "^5.4.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "watch": "tsc -w -p .",
     "lint": "tslint --project tslint.json",
     "lint-fix": "tslint --fix --project tslint.json",
-    "example": "ts-node ./src/examples/scrape"
+    "example": "ts-node ./src/examples/scrape",
+    "example-wait": "ts-node ./src/examples/waitForPageLoadSelector.ts"
   },
   "repository": {
     "type": "git",

--- a/src/contract-schema.ts
+++ b/src/contract-schema.ts
@@ -1,8 +1,10 @@
 import joi from '@hapi/joi';
 
-const buildSchema = (allowedTypes) => {
+const buildSchema = allowedTypes => {
   return joi.object({
     itemSelector: joi.string(),
+    waitForPageLoadSelector: joi.string(),
+    headless: joi.boolean().default(true),
     puppeteer: joi.boolean().default(true),
     scriptTagSelector: joi.string(),
     attributes: joi

--- a/src/contract-schema.ts
+++ b/src/contract-schema.ts
@@ -4,7 +4,6 @@ const buildSchema = allowedTypes => {
   return joi.object({
     itemSelector: joi.string(),
     waitForPageLoadSelector: joi.string(),
-    headless: joi.boolean().default(true),
     puppeteer: joi.boolean().default(true),
     scriptTagSelector: joi.string(),
     attributes: joi

--- a/src/examples/waitForPageLoadSelector.ts
+++ b/src/examples/waitForPageLoadSelector.ts
@@ -1,0 +1,44 @@
+import Scraper from '../../index';
+
+const contract = {
+  itemSelector: '.acheter-right .room',
+  waitForPageLoadSelector: '.acheter-right .room',
+  puppeteer: true,
+  attributes: {
+    name: {
+      type: 'text',
+      selector: '.title-wrap',
+    },
+    description: {
+      type: 'text',
+      selector: '.title-wrap',
+    },
+    price: {
+      type: 'number',
+      selector: '.card-top .card-right',
+    },
+    size: {
+      type: 'size',
+      selector: '.title-wrap',
+    },
+    link: {
+      type: 'link',
+      selector: '.title-wrap',
+      attribute: 'href',
+    },
+    photo: {
+      type: 'link',
+      selector: 'img',
+      attribute: 'src',
+    },
+  },
+};
+
+const scraper = new Scraper(
+  'http://www.stephaneplazaimmobilier-nantesest.com/catalog/result_carto.php?action=update_search&map_polygone=&C_28=Vente&C_28_search=EGAL&C_28_type=UNIQUE&site-agence=&C_65_search=CONTIENT&C_65_type=TEXT&C_65=44+NANTES&C_65_temp=44+NANTES&cfamille_id=&C_33_search=COMPRIS&C_33_type=TEXT&C_33_MIN=&C_33_MAX=&C_30_search=INFERIEUR&C_30_type=NUMBER&C_30=&C_30_format_quick=',
+  contract,
+);
+
+scraper.scrapePage().then(data => {
+  console.log(data);
+});

--- a/src/examples/waitForPageLoadSelector.ts
+++ b/src/examples/waitForPageLoadSelector.ts
@@ -37,6 +37,10 @@ const contract = {
 const scraper = new Scraper(
   'http://www.stephaneplazaimmobilier-nantesest.com/catalog/result_carto.php?action=update_search&map_polygone=&C_28=Vente&C_28_search=EGAL&C_28_type=UNIQUE&site-agence=&C_65_search=CONTIENT&C_65_type=TEXT&C_65=44+NANTES&C_65_temp=44+NANTES&cfamille_id=&C_33_search=COMPRIS&C_33_type=TEXT&C_33_MIN=&C_33_MAX=&C_30_search=INFERIEUR&C_30_type=NUMBER&C_30=&C_30_format_quick=',
   contract,
+  null,
+  {
+    headless: false,
+  },
 );
 
 scraper.scrapePage().then(data => {

--- a/src/fetcher/puppeteer.ts
+++ b/src/fetcher/puppeteer.ts
@@ -10,13 +10,13 @@ export default class PuppeteerFetcher implements Fetcher {
   private options: PuppeteerNodeLaunchOptions;
 
   constructor(
-    url,
-    waitForPageLoadSelector,
-    options: PuppeteerNodeLaunchOptions = { headless: true },
+    url: string,
+    waitForPageLoadSelector?: string,
+    options?: PuppeteerNodeLaunchOptions,
   ) {
     this.url = url;
     this.waitForPageLoadSelector = waitForPageLoadSelector;
-    this.options = options;
+    this.options = options || { headless: true };
   }
 
   public getBrowserType() {

--- a/src/fetcher/puppeteer.ts
+++ b/src/fetcher/puppeteer.ts
@@ -1,18 +1,22 @@
 import Fetcher from './fetcher';
 import { ScrapedPage } from '../fetcher/fetcher';
 import randomUserAgent from 'random-useragent';
-import puppeteer from 'puppeteer';
+import puppeteer, { PuppeteerNodeLaunchOptions } from 'puppeteer';
 import { getContentTypeHeaders, guessEncoding } from '../tools/encoding';
 
 export default class PuppeteerFetcher implements Fetcher {
   private url: string;
   private waitForPageLoadSelector: string;
-  private headless: boolean;
+  private options: PuppeteerNodeLaunchOptions;
 
-  constructor(url, waitForPageLoadSelector, headless = true) {
+  constructor(
+    url,
+    waitForPageLoadSelector,
+    options: PuppeteerNodeLaunchOptions = { headless: true },
+  ) {
     this.url = url;
     this.waitForPageLoadSelector = waitForPageLoadSelector;
-    this.headless = headless;
+    this.options = options;
   }
 
   public getBrowserType() {
@@ -26,7 +30,7 @@ export default class PuppeteerFetcher implements Fetcher {
     const browserType = this.getBrowserType();
     const userAgent = randomUserAgent.getRandom();
     const browser = await browserType.launch({
-      headless: this.headless,
+      headless: this.options.headless,
       args: [
         '--no-sandbox',
         '--disable-setuid-sandbox',

--- a/src/fetcher/puppeteer.ts
+++ b/src/fetcher/puppeteer.ts
@@ -6,22 +6,35 @@ import { getContentTypeHeaders, guessEncoding } from '../tools/encoding';
 
 export default class PuppeteerFetcher implements Fetcher {
   private url: string;
+  private waitForPageLoadSelector: string;
+  private headless: boolean;
 
-  constructor(url) {
+  constructor(url, waitForPageLoadSelector, headless = true) {
     this.url = url;
+    this.waitForPageLoadSelector = waitForPageLoadSelector;
+    this.headless = headless;
   }
 
   public getBrowserType() {
     return puppeteer;
   }
 
-  public async setupBrowser(): Promise<{ response: puppeteer.HTTPResponse, contents: string }> {
+  public async setupBrowser(): Promise<{
+    response: puppeteer.HTTPResponse;
+    contents: string;
+  }> {
     const browserType = this.getBrowserType();
     const userAgent = randomUserAgent.getRandom();
     const browser = await browserType.launch({
-      headless: true,
-      args: ['--no-sandbox', '--disable-setuid-sandbox', '--allow-insecure', '--disable-web-security'],
+      headless: this.headless,
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--allow-insecure',
+        '--disable-web-security',
+      ],
       ignoreHTTPSErrors: true,
+      slowMo: 10,
     });
 
     const page = await browser.newPage();
@@ -30,13 +43,18 @@ export default class PuppeteerFetcher implements Fetcher {
       await page.setUserAgent(userAgent);
       await page.setExtraHTTPHeaders({
         'Content-Type': 'text/html; charset=utf-8',
-        'Accept': 'text/html',
+        Accept: 'text/html',
         'Accept-Language': 'fr-FR',
       });
 
       await page.setViewport({ width: 1280, height: 1000 });
 
       const response = await page.goto(this.url);
+
+      if (this.waitForPageLoadSelector) {
+        await page.waitForSelector(this.waitForPageLoadSelector);
+      }
+
       const contents = await page.content();
 
       await page.close();
@@ -50,7 +68,6 @@ export default class PuppeteerFetcher implements Fetcher {
       console.log(`Error fetching ${this.url} with puppeteer`);
       throw e;
     }
-
   }
 
   async getPage(): Promise<ScrapedPage> {


### PR DESCRIPTION
- Add support for a new contract attribute `waitForPageLoadSelector`
- Fix logic for selecting the correct fetcher
- Add an option for passing puppeteer launch options when initialising a scraper